### PR TITLE
Update outdated stuff

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ LABEL maintainer="Jefferson J. Hunt <jeffersonjhunt@gmail.com>"
 ENV DEBIAN_FRONTEND=noninteractive
 ENV MAKEFLAGS='-j 8'
 
+RUN sed -i 's/deb.debian.org/archive.debian.org/' /etc/apt/sources.list
+
 # Ensure that we always use UTF-8, US English locale and UTC time
 RUN apt-get update && apt-get install -y locales && \
   localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
@@ -28,8 +30,8 @@ RUN apt-get install -y \
       swig \
       texinfo \
       dh-autoreconf \
-      python \
-      python-dev \
+      python2.7 \
+      python2.7-dev \
       gfortran \
       gr-osmosdr \
       gnuradio \

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,8 +102,8 @@ RUN git clone https://github.com/bitglue/gr-radioteletype.git && \
 RUN git clone https://github.com/kpreid/shinysdr.git && \
   cd shinysdr && \
   export PYTHONHTTPSVERIFY=0 && \
-  python setup.py build && \
-  python setup.py install && \
+  pip install typing Automat==20.2.0 && \
+  pip install . && \
   export PYTHONHTTPSVERIFY= && \
   cd /build && rm -rf /build/shinysdr
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PLATFORM=amd64
 FROM ${PLATFORM}/debian:10-slim
-LABEL maintainer "Jefferson J. Hunt <jeffersonjhunt@gmail.com>"
+LABEL maintainer="Jefferson J. Hunt <jeffersonjhunt@gmail.com>"
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV MAKEFLAGS='-j 8'

--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,8 @@ clean:
 
 deps:
 	mkdir -p assets
-	curl -k https://bootstrap.pypa.io/get-pip.py -o assets/get-pip.py
-	curl -k https://physics.princeton.edu/pulsar/K1JT/wsjtx-2.1.2.tgz -o assets/wsjtx-2.1.2.tgz
+	curl -k https://bootstrap.pypa.io/pip/2.7/get-pip.py -o assets/get-pip.py
+	curl -Lk https://sourceforge.net/projects/wsjt/files/wsjtx-2.1.2/wsjtx-2.1.2.tgz/download -o assets/wsjtx-2.1.2.tgz
 
 %/run:
 	$(DOCKER) run --rm -p 8100:8100 -p 8101:8101 -v ~/.shinysdr:/config \


### PR DESCRIPTION
This project currently does not build anymore. This PR makes it build again with the latest versions of shinysdr and its plugins

Tested on arm64 (Raspberry PI 5), should work on all architectures

List of changes:

- fixed docker build warning due to missing `=` in the `label` annotation
- debian buster has been archived and its repositories moved to `archive.debian.org`
- `python` and `python-dev` packages for python 2 are now called `python2.7` and `python2.7-dev`
- `setup.py` installation for shinysdr did not work for me with multiple different errors, switched to `pip install` which worked on the first try
- added two missing dependencies for shinysdr (`typing` and `Automat`, with the latter version pinned to support python 2.7)
- both urls in the `deps` target of the makefile were 404 due to link rot. Replaced with new official urls